### PR TITLE
backport /dev/secstore (in devcons.c) to allow drawterm to remember your secrets

### DIFF
--- a/cpu.c
+++ b/cpu.c
@@ -27,6 +27,7 @@ static int	aanto = 3600 * 24;
 static int	norcpu;
 static int	nokbd;
 static int	nogfx;
+static int  keepSecstore;
 
 static char	*ealgs = "rc4_256 sha1";
 
@@ -37,10 +38,10 @@ static int	p9authtls(int);
 char *authserver;
 char *secstore;
 char *user, *pass;
-char secstorebuf[65536];
 char *geometry;
 
 extern void	guimain(void);
+extern char secstorebuf[65536];
 
 char*
 estrdup(char *s)
@@ -167,8 +168,9 @@ rcpu(char *host, char *cmd)
 			sysfatal("startaan: %r");
 		fd = p9authtls(fd);
 	}
-	memset(secstorebuf, 0, sizeof(secstorebuf));	/* forget secstore secrets */
 
+	if(! keepSecstore)
+		memset(secstorebuf, 0, sizeof(secstorebuf));	/* forget secstore secrets */
 	if(cmd == nil)
 		cmd = smprint(script, "rc -li");
 	else {
@@ -300,6 +302,9 @@ cpumain(int argc, char **argv)
 		break;
 	case 's':
 		secstore = EARGF(usage());
+		break;
+	case 'S':
+		keepSecstore = 1;
 		break;
 	case 'e':
 		ealgs = EARGF(usage());
@@ -443,7 +448,8 @@ p9authssl(int fd)
 	AuthInfo *ai;
 
 	ai = p9any(fd);
-	memset(secstorebuf, 0, sizeof(secstorebuf));	/* forget secstore secrets */
+	if(! keepSecstore)
+		memset(secstorebuf, 0, sizeof(secstorebuf));	/* forget secstore secrets */
 	if(ai == nil)
 		sysfatal("can't authenticate: %r");
 

--- a/drawterm.1
+++ b/drawterm.1
@@ -20,6 +20,8 @@ drawterm  \- connection to cpu, fs, and auth servers
 .B -s
 .I secstore
 ] [
+.B -S
+] [
 .B -e
 \fR'\fIcrypt hash\fR'
 ] [
@@ -84,6 +86,11 @@ Sets the address of the
 server. If the -s option is absent,
 .IR secstore (1)
 will attempt to dial tcp!$auth!secstore (or the otherwise specified auth server).
+
+.TP
+.B -S
+Instructs drawterm to preserve the contents of any secstore secrets it learns in /dev/secstore. This can then be used to initialise a factotum on plan9. This store should be wiped once it has been read thus:
+.IR cp /dev/zero /mnt/term/dev/secstore .
 
 .TP
 .B -e \fR'\fIcrypt hash\fR'

--- a/kern/devcons.c
+++ b/kern/devcons.c
@@ -344,6 +344,7 @@ enum{
 	Qppid,
 	Qrandom,
 	Qreboot,
+	Qsecstore,
 	Qshowfile,
 	Qsnarf,
 	Qsysname,
@@ -376,6 +377,7 @@ static Dirtab consdir[]={
 	"ppid",		{Qppid},	NUMSIZE,	0444,
 	"random",	{Qrandom},	0,		0444,
 	"reboot",	{Qreboot},	0,		0664,
+	"secstore",	{Qsecstore},	0,		0666,
 	"showfile",	{Qshowfile},	0,	0220,
 	"snarf",	{Qsnarf},		0,		0666,
 	"sysname",	{Qsysname},	0,		0664,
@@ -385,6 +387,8 @@ static Dirtab consdir[]={
 	"zero",		{Qzero},	0,		0444,
 };
 
+char secstorebuf[65536];
+Dirtab *secstoretab = &consdir[Qsecstore];
 Dirtab *snarftab = &consdir[Qsnarf];
 
 int
@@ -467,6 +471,13 @@ consopen(Chan *c, int omode)
 		}else
 			qreopen(kprintoq);
 		c->iounit = qiomaxatomic;
+		break;
+
+	case Qsecstore:
+		if(omode == ORDWR)
+			error(Eperm);
+		if(omode != OREAD)
+			memset(secstorebuf, 0, sizeof secstorebuf);
 		break;
 
 	case Qsnarf:
@@ -646,6 +657,9 @@ consread(Chan *c, void *buf, long n, vlong off)
 			return 0;
 		return readstr(offset, buf, n, c->aux);
 
+	case Qsecstore:
+		return readstr(offset, buf, n, secstorebuf);
+
 	case Qsysstat:
 		return 0;
 
@@ -787,6 +801,13 @@ conswrite(Chan *c, void *va, long n, vlong off)
 		poperror();
 		free(cb);
 		break;
+
+	case Qsecstore:
+		if(offset >= sizeof secstorebuf || offset+n+1 >= sizeof secstorebuf)
+			error(Etoobig);
+		secstoretab->qid.vers++;
+		memmove(secstorebuf+offset, va, n);
+		return n;
 
 	case Qshowfile:
 		return showfilewrite(a, n);


### PR DESCRIPTION
backport /dev/secstore (in devcons.c) to allow drawterm to remember your secrets to initialise factotum's database.

I am guessing this was removed on security grounds (which I understand) so this behaviour is only enabled with the -S command line option.
