### PR TITLE
Add support for geometry option to gui-metal

### DIFF
--- a/gui-metal/Makefile
+++ b/gui-metal/Makefile
@@ -3,7 +3,8 @@ include ../Make.config
 LIB=libgui.a
 
 OFILES=\
-	screen.$O
+	screen.$O \
+	ParseGeom.$O
 
 default: $(LIB)
 $(LIB): $(OFILES)

--- a/gui-metal/ParseGeom.c
+++ b/gui-metal/ParseGeom.c
@@ -1,0 +1,162 @@
+
+/*
+
+Copyright 1985, 1986, 1987,1998  The Open Group
+
+Permission to use, copy, modify, distribute, and sell this software and its
+documentation for any purpose is hereby granted without fee, provided that
+the above copyright notice appear in all copies and that both that
+copyright notice and this permission notice appear in supporting
+documentation.
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE OPEN GROUP BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name of The Open Group shall
+not be used in advertising or otherwise to promote the sale, use or
+other dealings in this Software without prior written authorization
+from The Open Group.
+
+*/
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#include "Xlibint.h"
+#include "Xutil.h"
+
+/*
+ *    XParseGeometry parses strings of the form
+ *   "=<width>x<height>{+-}<xoffset>{+-}<yoffset>", where
+ *   width, height, xoffset, and yoffset are unsigned integers.
+ *   Example:  "=80x24+300-49"
+ *   The equal sign is optional.
+ *   It returns a bitmask that indicates which of the four values
+ *   were actually found in the string.  For each value found,
+ *   the corresponding argument is updated;  for each value
+ *   not found, the corresponding argument is left unchanged.
+ */
+
+static int
+ReadInteger(char *string, char **NextString)
+{
+    register int Result = 0;
+    int Sign = 1;
+
+    if (*string == '+')
+	string++;
+    else if (*string == '-')
+    {
+	string++;
+	Sign = -1;
+    }
+    for (; (*string >= '0') && (*string <= '9'); string++)
+    {
+	Result = (Result * 10) + (*string - '0');
+    }
+    *NextString = string;
+    if (Sign >= 0)
+	return (Result);
+    else
+	return (-Result);
+}
+
+int
+XParseGeometry (
+_Xconst char *string,
+int *x,
+int *y,
+unsigned int *width,    /* RETURN */
+unsigned int *height)    /* RETURN */
+{
+	int mask = NoValue;
+	register char *strind;
+	unsigned int tempWidth = 0, tempHeight = 0;
+	int tempX = 0, tempY = 0;
+	char *nextCharacter;
+
+	if ( (string == NULL) || (*string == '\0')) return(mask);
+	if (*string == '=')
+		string++;  /* ignore possible '=' at beg of geometry spec */
+
+	strind = (char *)string;
+	if (*strind != '+' && *strind != '-' && *strind != 'x') {
+		tempWidth = ReadInteger(strind, &nextCharacter);
+		if (strind == nextCharacter)
+		    return (0);
+		strind = nextCharacter;
+		mask |= WidthValue;
+	}
+
+	if (*strind == 'x' || *strind == 'X') {
+		strind++;
+		tempHeight = ReadInteger(strind, &nextCharacter);
+		if (strind == nextCharacter)
+		    return (0);
+		strind = nextCharacter;
+		mask |= HeightValue;
+	}
+
+	if ((*strind == '+') || (*strind == '-')) {
+		if (*strind == '-') {
+  			strind++;
+			tempX = -ReadInteger(strind, &nextCharacter);
+			if (strind == nextCharacter)
+			    return (0);
+			strind = nextCharacter;
+			mask |= XNegative;
+
+		}
+		else
+		{	strind++;
+			tempX = ReadInteger(strind, &nextCharacter);
+			if (strind == nextCharacter)
+			    return(0);
+			strind = nextCharacter;
+		}
+		mask |= XValue;
+		if ((*strind == '+') || (*strind == '-')) {
+			if (*strind == '-') {
+				strind++;
+				tempY = -ReadInteger(strind, &nextCharacter);
+				if (strind == nextCharacter)
+			    	    return(0);
+				strind = nextCharacter;
+				mask |= YNegative;
+
+			}
+			else
+			{
+				strind++;
+				tempY = ReadInteger(strind, &nextCharacter);
+				if (strind == nextCharacter)
+			    	    return(0);
+				strind = nextCharacter;
+			}
+			mask |= YValue;
+		}
+	}
+
+	/* If strind isn't at the end of the string the it's an invalid
+		geometry specification. */
+
+	if (*strind != '\0') return (0);
+
+	if (mask & XValue)
+	    *x = tempX;
+ 	if (mask & YValue)
+	    *y = tempY;
+	if (mask & WidthValue)
+            *width = tempWidth;
+	if (mask & HeightValue)
+            *height = tempHeight;
+	return (mask);
+}

--- a/gui-metal/ParseGeom.c
+++ b/gui-metal/ParseGeom.c
@@ -30,8 +30,7 @@ from The Open Group.
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
-#include "Xlibint.h"
-#include "Xutil.h"
+#include <stddef.h>
 
 /*
  *    XParseGeometry parses strings of the form
@@ -71,19 +70,18 @@ ReadInteger(char *string, char **NextString)
 
 int
 XParseGeometry (
-_Xconst char *string,
+const char *string,
 int *x,
 int *y,
 unsigned int *width,	/* RETURN */
 unsigned int *height)	 /* RETURN */
 {
-	int mask = NoValue;
 	register char *strind;
 	unsigned int tempWidth = 0, tempHeight = 0;
 	int tempX = 0, tempY = 0;
 	char *nextCharacter;
 
-	if ( (string == NULL) || (*string == '\0')) return(mask);
+	if ( (string == NULL) || (*string == '\0')) return(0);
 	if (*string == '=')
 		string++;  /* ignore possible '=' at beg of geometry spec */
 
@@ -93,7 +91,6 @@ unsigned int *height)	 /* RETURN */
 		if (strind == nextCharacter)
 			return (0);
 		strind = nextCharacter;
-		mask |= WidthValue;
 	}
 
 	if (*strind == 'x' || *strind == 'X') {
@@ -102,7 +99,6 @@ unsigned int *height)	 /* RETURN */
 		if (strind == nextCharacter)
 			return (0);
 		strind = nextCharacter;
-		mask |= HeightValue;
 	}
 
 	if ((*strind == '+') || (*strind == '-')) {
@@ -112,7 +108,6 @@ unsigned int *height)	 /* RETURN */
 			if (strind == nextCharacter)
 				return (0);
 			strind = nextCharacter;
-			mask |= XNegative;
 
 		}
 		else
@@ -123,7 +118,6 @@ unsigned int *height)	 /* RETURN */
 				return(0);
 			strind = nextCharacter;
 		}
-		mask |= XValue;
 		if ((*strind == '+') || (*strind == '-')) {
 			if (*strind == '-') {
 			strind++;
@@ -131,7 +125,6 @@ unsigned int *height)	 /* RETURN */
 			if (strind == nextCharacter)
 					return(0);
 			strind = nextCharacter;
-			mask |= YNegative;
 
 			}
 			else
@@ -142,7 +135,6 @@ unsigned int *height)	 /* RETURN */
 				return(0);
 				strind = nextCharacter;
 			}
-			mask |= YValue;
 		}
 	}
 
@@ -151,13 +143,9 @@ unsigned int *height)	 /* RETURN */
 
 	if (*strind != '\0') return (0);
 
-	if (mask & XValue)
-		*x = tempX;
-	if (mask & YValue)
-		*y = tempY;
-	if (mask & WidthValue)
-		*width = tempWidth;
-	if (mask & HeightValue)
-		*height = tempHeight;
-	return (mask);
+	*x = tempX;
+	*y = tempY;
+	*width = tempWidth;
+	*height = tempHeight;
+	return (0);
 }

--- a/gui-metal/ParseGeom.c
+++ b/gui-metal/ParseGeom.c
@@ -48,25 +48,25 @@ from The Open Group.
 static int
 ReadInteger(char *string, char **NextString)
 {
-    register int Result = 0;
-    int Sign = 1;
+	register int Result = 0;
+	int Sign = 1;
 
-    if (*string == '+')
-	string++;
-    else if (*string == '-')
-    {
-	string++;
-	Sign = -1;
-    }
-    for (; (*string >= '0') && (*string <= '9'); string++)
-    {
-	Result = (Result * 10) + (*string - '0');
-    }
-    *NextString = string;
-    if (Sign >= 0)
-	return (Result);
-    else
-	return (-Result);
+	if (*string == '+')
+		string++;
+	else if (*string == '-')
+	{
+		string++;
+		Sign = -1;
+	}
+	for (; (*string >= '0') && (*string <= '9'); string++)
+	{
+		Result = (Result * 10) + (*string - '0');
+	}
+	*NextString = string;
+	if (Sign >= 0)
+		return (Result);
+	else
+		return (-Result);
 }
 
 int
@@ -74,8 +74,8 @@ XParseGeometry (
 _Xconst char *string,
 int *x,
 int *y,
-unsigned int *width,    /* RETURN */
-unsigned int *height)    /* RETURN */
+unsigned int *width,	/* RETURN */
+unsigned int *height)	 /* RETURN */
 {
 	int mask = NoValue;
 	register char *strind;
@@ -91,7 +91,7 @@ unsigned int *height)    /* RETURN */
 	if (*strind != '+' && *strind != '-' && *strind != 'x') {
 		tempWidth = ReadInteger(strind, &nextCharacter);
 		if (strind == nextCharacter)
-		    return (0);
+			return (0);
 		strind = nextCharacter;
 		mask |= WidthValue;
 	}
@@ -100,45 +100,46 @@ unsigned int *height)    /* RETURN */
 		strind++;
 		tempHeight = ReadInteger(strind, &nextCharacter);
 		if (strind == nextCharacter)
-		    return (0);
+			return (0);
 		strind = nextCharacter;
 		mask |= HeightValue;
 	}
 
 	if ((*strind == '+') || (*strind == '-')) {
 		if (*strind == '-') {
-  			strind++;
+			strind++;
 			tempX = -ReadInteger(strind, &nextCharacter);
 			if (strind == nextCharacter)
-			    return (0);
+				return (0);
 			strind = nextCharacter;
 			mask |= XNegative;
 
 		}
 		else
-		{	strind++;
+		{
+			strind++;
 			tempX = ReadInteger(strind, &nextCharacter);
 			if (strind == nextCharacter)
-			    return(0);
+				return(0);
 			strind = nextCharacter;
 		}
 		mask |= XValue;
 		if ((*strind == '+') || (*strind == '-')) {
 			if (*strind == '-') {
-				strind++;
-				tempY = -ReadInteger(strind, &nextCharacter);
-				if (strind == nextCharacter)
-			    	    return(0);
-				strind = nextCharacter;
-				mask |= YNegative;
+			strind++;
+			tempY = -ReadInteger(strind, &nextCharacter);
+			if (strind == nextCharacter)
+					return(0);
+			strind = nextCharacter;
+			mask |= YNegative;
 
 			}
 			else
 			{
-				strind++;
-				tempY = ReadInteger(strind, &nextCharacter);
-				if (strind == nextCharacter)
-			    	    return(0);
+			strind++;
+			tempY = ReadInteger(strind, &nextCharacter);
+			if (strind == nextCharacter)
+				return(0);
 				strind = nextCharacter;
 			}
 			mask |= YValue;
@@ -146,17 +147,17 @@ unsigned int *height)    /* RETURN */
 	}
 
 	/* If strind isn't at the end of the string the it's an invalid
-		geometry specification. */
+	geometry specification. */
 
 	if (*strind != '\0') return (0);
 
 	if (mask & XValue)
-	    *x = tempX;
- 	if (mask & YValue)
-	    *y = tempY;
+		*x = tempX;
+	if (mask & YValue)
+		*y = tempY;
 	if (mask & WidthValue)
-            *width = tempWidth;
+		*width = tempWidth;
 	if (mask & HeightValue)
-            *height = tempHeight;
+		*height = tempHeight;
 	return (mask);
 }

--- a/gui-metal/ParseGeom.c
+++ b/gui-metal/ParseGeom.c
@@ -31,6 +31,7 @@ from The Open Group.
 #include <config.h>
 #endif
 #include <stddef.h>
+#include "ParseGeom.h"
 
 /*
  *    XParseGeometry parses strings of the form
@@ -76,12 +77,13 @@ int *y,
 unsigned int *width,	/* RETURN */
 unsigned int *height)	 /* RETURN */
 {
+	int mask = NoValue;
 	register char *strind;
 	unsigned int tempWidth = 0, tempHeight = 0;
 	int tempX = 0, tempY = 0;
 	char *nextCharacter;
 
-	if ( (string == NULL) || (*string == '\0')) return(0);
+	if ( (string == NULL) || (*string == '\0')) return(mask);
 	if (*string == '=')
 		string++;  /* ignore possible '=' at beg of geometry spec */
 
@@ -91,6 +93,7 @@ unsigned int *height)	 /* RETURN */
 		if (strind == nextCharacter)
 			return (0);
 		strind = nextCharacter;
+		mask |= WidthValue;
 	}
 
 	if (*strind == 'x' || *strind == 'X') {
@@ -99,6 +102,7 @@ unsigned int *height)	 /* RETURN */
 		if (strind == nextCharacter)
 			return (0);
 		strind = nextCharacter;
+		mask |= HeightValue;
 	}
 
 	if ((*strind == '+') || (*strind == '-')) {
@@ -108,6 +112,7 @@ unsigned int *height)	 /* RETURN */
 			if (strind == nextCharacter)
 				return (0);
 			strind = nextCharacter;
+			mask |= XNegative;
 
 		}
 		else
@@ -118,6 +123,7 @@ unsigned int *height)	 /* RETURN */
 				return(0);
 			strind = nextCharacter;
 		}
+		mask |= XValue;
 		if ((*strind == '+') || (*strind == '-')) {
 			if (*strind == '-') {
 			strind++;
@@ -125,6 +131,7 @@ unsigned int *height)	 /* RETURN */
 			if (strind == nextCharacter)
 					return(0);
 			strind = nextCharacter;
+			mask |= YNegative;
 
 			}
 			else
@@ -136,6 +143,7 @@ unsigned int *height)	 /* RETURN */
 				strind = nextCharacter;
 			}
 		}
+		mask |= YValue;
 	}
 
 	/* If strind isn't at the end of the string the it's an invalid
@@ -143,9 +151,13 @@ unsigned int *height)	 /* RETURN */
 
 	if (*strind != '\0') return (0);
 
-	*x = tempX;
-	*y = tempY;
-	*width = tempWidth;
-	*height = tempHeight;
-	return (0);
+	if (mask & XValue)
+		*x = tempX;
+	if (mask & YValue)
+		*y = tempY;
+	if (mask & WidthValue)
+		*width = tempWidth;
+	if (mask & HeightValue)
+		*height = tempHeight;
+	return (mask);
 }

--- a/gui-metal/ParseGeom.h
+++ b/gui-metal/ParseGeom.h
@@ -1,0 +1,20 @@
+/*
+ * Bitmask returned by XParseGeometry().  Each bit tells if the corresponding
+ * value (x, y, width, height) was found in the parsed string.
+ */
+#define NoValue		0x0000
+#define XValue  	0x0001
+#define YValue		0x0002
+#define WidthValue  	0x0004
+#define HeightValue  	0x0008
+#define AllValues 	0x000F
+#define XNegative 	0x0010
+#define YNegative 	0x0020
+
+int
+XParseGeometry (
+const char *string,
+int *x,
+int *y,
+unsigned int *width,    /* RETURN */
+unsigned int *height);    /* RETURN */

--- a/gui-metal/screen.m
+++ b/gui-metal/screen.m
@@ -17,16 +17,10 @@
 #include "screen.h"
 #include "keyboard.h"
 #include "ball9png.h"
+#include "ParseGeom.h"
 
 extern char		*geometry;	/* defined in cpu.c */
 
-int
-XParseGeometry (
-const char *string,
-int *x,
-int *y,
-unsigned int *width,    /* RETURN */
-unsigned int *height);    /* RETURN */
 #ifndef DEBUG
 #define DEBUG 0
 #endif
@@ -349,12 +343,16 @@ mainproc(void *aux)
 	r.size.width = s.size.width*sizeFactor;
 	r.size.height = s.size.height*sizeFactor;
 	if (geometry != NULL) {
-		unsigned int width = r.size.width;
-		unsigned int height = r.size.height;
+		unsigned int width = 0;
+		unsigned int height = 0;
 		int xoff = 0;
 		int yoff = 0;
-		XParseGeometry(geometry, &xoff, &yoff, &width, &height);
+		int mask = XParseGeometry(geometry, &xoff, &yoff, &width, &height);
 		CGFloat goldenRatio = 1.61833;
+		if (!(mask & WidthValue || mask & HeightValue)) {
+			width = r.size.width;
+			height = r.size.height;
+		}
 		if (width == 0) {
 			width = height * goldenRatio;
 		}

--- a/gui-x11/x11.c
+++ b/gui-x11/x11.c
@@ -50,7 +50,7 @@ static	Drawable	xscreenid;
 static	XImage*		xscreenimage;
 static	Visual		*xvis;
 
-extern char		*geometry;	/* defined in main.c */
+extern char		*geometry;	/* defined in cpu.c */
 
 #include "../glenda-t.xbm"
 


### PR DESCRIPTION
I noticed that for gut-metal `drawterm` ignores the `-g geometry` option and always places the `drawterm` window in the center of the screen at ¾ of the screen size.

The changes in this PR set the position and size of the `drawterm` window according to the `-g geometry` option and defaulting to the existing behaviour when the `-g` option has not been given.