### PR TITLE
Make.osx-metal: remove -march=native from CFLAGS

### DIFF
--- a/Make.osx-metal
+++ b/Make.osx-metal
@@ -4,7 +4,7 @@ AR=ar
 AS=as
 RANLIB=ranlib
 CC=xcrun --sdk macosx clang
-CFLAGS=-Wall -Wno-missing-braces -g -I$(ROOT) -I$(ROOT)/include -I$(ROOT)/kern -c -D_THREAD_SAFE $(PTHREAD) -march=native -O2 -flto $(DEBUGCFLAGS)
+CFLAGS=-Wall -Wno-missing-braces -g -I$(ROOT) -I$(ROOT)/include -I$(ROOT)/kern -c -D_THREAD_SAFE $(PTHREAD) -O2 -flto $(DEBUGCFLAGS)
 O=o
 OS=posix
 GUI=metal


### PR DESCRIPTION
clang on macOS on Apple Silicon has no native march